### PR TITLE
Filtrer posisjonene for å få riktig data

### DIFF
--- a/systems/visma/validator.js
+++ b/systems/visma/validator.js
@@ -48,7 +48,7 @@ module.exports = (systemData, user, allData = false) => ([
       return error('Ingen stillinger ble funnet i HRM', { employment, positions: (positions || null) })
     }
 
-    const primaryPositions = positions.map(position => position['@isPrimaryPosition'] === 'true')
+    const primaryPositions = positions.filter(position => position['@isPrimaryPosition'] === 'true')
     const activePrimaryPositions = primaryPositions.map(position => position.active)
     const activePrimaryPosition = activePrimaryPositions.includes(true)
 


### PR DESCRIPTION
Fikser feilen hvor det finnes aktive ansettelsesforhold men ingen hovedstilling, selvom en av de har hovedstilling

`azf-dust-api - 1.0.0: DEMO - testing - visma-02 - Aktiv stilling - Fant et aktivt ansettelsesforhold i HRM, men ingen av de aktive stillingene er en hovedstilling`