### PR TITLE
Fixes 160321

### DIFF
--- a/DUSTOrchestrator/index.js
+++ b/DUSTOrchestrator/index.js
@@ -27,6 +27,9 @@ module.exports = df.orchestrator(function * (context) {
     if (!systems.includes(system.toLowerCase())) systems.push(system.toLowerCase())
   })
 
+  // set current user object to customStatus
+  context.df.setCustomStatus(user)
+
   // create a new request in the db
   yield context.df.callActivity('WorkerActivity', {
     type: 'db',
@@ -79,6 +82,9 @@ module.exports = df.orchestrator(function * (context) {
         user
       }
     })
+
+    // set current user object to customStatus
+    context.df.setCustomStatus(user)
 
     // start systems which failed validation
     parallelTasks.push(...callSystems(context, instanceId, failedValidation, user, token))

--- a/DUSTOrchestrator/index.js
+++ b/DUSTOrchestrator/index.js
@@ -31,7 +31,7 @@ module.exports = df.orchestrator(function * (context) {
   context.df.setCustomStatus(user)
 
   // create a new request in the db
-  yield context.df.callActivity('WorkerActivity', {
+  const newEntry = yield context.df.callActivity('WorkerActivity', {
     type: 'db',
     variant: 'new',
     query: {
@@ -115,19 +115,20 @@ module.exports = df.orchestrator(function * (context) {
   })
 
   // update request with a finish timestamp and user object
-  const timestamp = new Date().toISOString()
-  yield context.df.callActivity('WorkerActivity', {
+  const updatedEntry = yield context.df.callActivity('WorkerActivity', {
     type: 'db',
     variant: 'update',
     query: {
       instanceId,
-      timestamp,
+      timestamp: new Date().toISOString(),
       user
     }
   })
 
   return {
     user,
+    started: newEntry.started,
+    finished: updatedEntry.$set.finished,
     data: parallelTasks.map(task => {
       return {
         name: task.result.name,

--- a/DUSTOrchestrator/index.js
+++ b/DUSTOrchestrator/index.js
@@ -132,12 +132,12 @@ module.exports = df.orchestrator(function * (context) {
     data: parallelTasks.map(task => {
       return {
         name: task.result.name,
+        timestamp: task.timestamp,
         data: task.result.data || undefined,
-        test: task.result.test || undefined,
-        statusCode: task.result.status || 200,
         error: task.result.error || undefined,
+        statusCode: task.result.status || 200,
         innerError: task.result.innerError || undefined,
-        timestamp: task.timestamp
+        test: task.result.test || undefined,
       }
     })
   }

--- a/DUSTOrchestrator/index.js
+++ b/DUSTOrchestrator/index.js
@@ -16,7 +16,7 @@ module.exports = df.orchestrator(function * (context) {
   const input = context.df.getInput()
   const { token } = input
   const instanceId = context.df.instanceId
-  const parallelTasks = []
+  let parallelTasks = []
   let { body: { systems, user } } = input
 
   // lowercase all system names
@@ -98,12 +98,12 @@ module.exports = df.orchestrator(function * (context) {
   yield context.df.Task.all(parallelTasks)
 
   // run all tests on all systems
-  yield context.df.callActivity('WorkerActivity', {
+  parallelTasks = yield context.df.callActivity('WorkerActivity', {
     type: 'test',
     variant: 'all',
     query: {
       instanceId,
-      results: parallelTasks.filter(task => task.result.data).map(task => task.result),
+      tasks: parallelTasks,
       user
     }
   })

--- a/DUSTOrchestrator/index.js
+++ b/DUSTOrchestrator/index.js
@@ -137,7 +137,7 @@ module.exports = df.orchestrator(function * (context) {
         error: task.result.error || undefined,
         statusCode: task.result.status || 200,
         innerError: task.result.innerError || undefined,
-        test: task.result.test || undefined,
+        test: task.result.test || undefined
       }
     })
   }

--- a/HttpStatus/index.js
+++ b/HttpStatus/index.js
@@ -6,7 +6,7 @@ const { RETRY_WAIT } = require('../config')
 const status = async function (context, req) {
   const client = df.getClient(context)
   const { instanceId } = req.params
-  const status = await client.getStatus(instanceId, true)
+  const status = await client.getStatus(instanceId, true, true)
 
   // remove input from status object if everything is fine
   if (status.input && !([status.runtimeStatus, status.customStatus].includes('Failed'))) {

--- a/HttpStatus/index.js
+++ b/HttpStatus/index.js
@@ -31,7 +31,12 @@ const status = async function (context, req) {
   if (status && ['Running', 'Pending'].includes(status.runtimeStatus)) {
     res = {
       ...getStatusResponse(client, instanceId, RETRY_WAIT),
-      body: status
+      body: {
+        user: status.customStatus,
+        started: status.createdTime,
+        lastUpdated: status.lastUpdatedTime,
+        data: status.historyEvents.filter(event => event.Result && event.Result.name).map(event => event.Result)
+      }
     }
   }
 

--- a/lib/mongo/handle-mongo.js
+++ b/lib/mongo/handle-mongo.js
@@ -3,39 +3,31 @@ const mongo = require('./get-mongo')
 const { DEMO_SKIP_DB } = require('../../config')
 
 module.exports.newRequest = async request => {
-  if (DEMO_SKIP_DB) {
-    logger('warn', ['handle-mongo', 'new-request', 'DEMO'])
-    return true
-  }
-
-  const db = await mongo()
   const { instanceId, systems, user } = request
-
-  logger('info', ['handle-mongo', 'new-request', 'start'])
-  const result = await db.insertOne({
+  const data = {
     instanceId,
     user,
     started: new Date().toISOString(),
     finished: null,
     systems: systems.map(system => { return { name: system, tests: [] } })
-  })
-  logger('info', ['handle-mongo', 'new-request', 'finish'])
+  }
 
-  return result
-}
-
-module.exports.updateRequest = async request => {
   if (DEMO_SKIP_DB) {
-    logger('warn', ['handle-mongo', 'update-request', 'DEMO'])
-    return true
+    logger('warn', ['handle-mongo', 'new-request', 'DEMO'])
+    return data
   }
 
   const db = await mongo()
+  logger('info', ['handle-mongo', 'new-request', 'start'])
+  const result = await db.insertOne(data)
+  logger('info', ['handle-mongo', 'new-request', 'finish'])
+  return result ? data : result
+}
+
+module.exports.updateRequest = async request => {
   const { instanceId, name, data, user, status, error, innerError, test, timestamp } = request
   const setQuery = { $set: {} }
   const filter = { instanceId }
-
-  logger('info', ['handle-mongo', 'update-request', 'start'])
 
   if (data !== undefined) setQuery.$set['systems.$.data'] = data
   if (status !== undefined) setQuery.$set['systems.$.status'] = status
@@ -51,14 +43,27 @@ module.exports.updateRequest = async request => {
     return false
   }
 
+  if (DEMO_SKIP_DB) {
+    logger('warn', ['handle-mongo', 'update-request', 'DEMO'])
+    return setQuery
+  }
+
+  const db = await mongo()
+  logger('info', ['handle-mongo', 'update-request', 'start'])
   const result = await db.updateOne(
     filter,
     {
       ...setQuery
     }
   )
-
   logger('info', ['handle-mongo', 'update-request', 'finish', result.modifiedCount])
+  return result.modifiedCount > 0 ? setQuery : false
+}
 
+module.exports.getRequest = async instanceId => {
+  const db = await mongo()
+  logger('info', ['handle-mongo', 'get-request', 'start'])
+  const result = await db.findOne({ instanceId })
+  logger('info', ['handle-mongo', 'get-request', 'finish'])
   return result
 }

--- a/systems/feide/validator.js
+++ b/systems/feide/validator.js
@@ -115,7 +115,7 @@ module.exports = (systemData, user, allData = false) => ([
     }
     return success('PrincipalName er satt', data)
   }),
-  test('feide-12', `PrincipalName er lik "uid${SYSTEMS.FEIDE.PRINCIPAL_NAME}"`, `Sjekker at PrincipalName er lik "uid${SYSTEMS.FEIDE.PRINCIPAL_NAME}"`, () => {
+  test('feide-12', `PrincipalName er lik 'uid${SYSTEMS.FEIDE.PRINCIPAL_NAME}'`, `Sjekker at PrincipalName er lik 'uid${SYSTEMS.FEIDE.PRINCIPAL_NAME}'`, () => {
     if (!systemData.eduPersonPrincipalName === `${systemData.name}${SYSTEMS.FEIDE.PRINCIPAL_NAME}`) return error('PrincipalName er feil 🤭', systemData)
     const data = {
       eduPersonPrincipalName: systemData.eduPersonPrincipalName

--- a/systems/feide/validator.js
+++ b/systems/feide/validator.js
@@ -148,7 +148,7 @@ module.exports = (systemData, user, allData = false) => ([
   test('feide-15', 'Har satt opp MFA', 'Sjekker at MFA er satt opp', () => {
     if (!systemData.norEduPersonAuthnMethod) return error('MFA mangler 🤭', systemData)
     const data = {
-      norEduPersonAuthnMethod: systemData.norEduPersonAuthnMethod
+      norEduPersonAuthnMethod: systemData.norEduPersonAuthnMethod.map(auth => auth.split(' ')[0])
     }
     if (systemData.norEduPersonAuthnMethod.length > 0) {
       const smsAuth = systemData.norEduPersonAuthnMethod.map(auth => auth.includes('urn:mace:feide.no:auth:method:sms'))

--- a/systems/feide/validator.js
+++ b/systems/feide/validator.js
@@ -151,8 +151,9 @@ module.exports = (systemData, user, allData = false) => ([
       norEduPersonAuthnMethod: systemData.norEduPersonAuthnMethod.map(auth => auth.split(' ')[0])
     }
     if (systemData.norEduPersonAuthnMethod.length > 0) {
-      const smsAuth = systemData.norEduPersonAuthnMethod.map(auth => auth.includes('urn:mace:feide.no:auth:method:sms'))
-      const gaAuth = systemData.norEduPersonAuthnMethod.map(auth => auth.includes('urn:mace:feide.no:auth:method:ga'))
+      const smsAuth = systemData.norEduPersonAuthnMethod.filter(auth => auth.includes('urn:mace:feide.no:auth:method:sms'))
+      const gaAuth = systemData.norEduPersonAuthnMethod.filter(auth => auth.includes('urn:mace:feide.no:auth:method:ga'))
+
       if (smsAuth.length > 0 && gaAuth.length > 0) return success('MFA for SMS og Godkjenner/Authenticator app er satt opp', data)
       else if (smsAuth.length > 0 && gaAuth.length === 0) return success('MFA for SMS er satt opp', data)
       else if (smsAuth.length === 0 && gaAuth.length > 0) return success('MFA for Godkjenner/Authenticator app er satt opp', data)

--- a/systems/feide/validator.js
+++ b/systems/feide/validator.js
@@ -56,10 +56,10 @@ module.exports = (systemData, user, allData = false) => ([
     const isPwdOk = isPwdLastSet(pwdAd, pwdFeide)
     const data = {
       feide: {
-        passwordLastSet: allData.feide.passwordLastSet
+        passwordLastSet: systemData.passwordLastSet
       },
       ad: {
-        pwdLastSet: systemData.pwdLastSet
+        pwdLastSet: allData.ad.pwdLastSet
       },
       seconds: isPwdOk.seconds
     }


### PR DESCRIPTION
- Alle data og tester følger med ut i resultatet sendt tilbake fra DF
- User objektet sendt inn blir satt til customStatus så vi kan hente det ut i status endepunktet. Dersom user objektet oppdateres underveis oppdateres det også i customStatus
- Mer lesbartt 👴🏼 resultat
- Lagt til en `DEMO_SKIP_DB` config for å holde alt lokalt ved tester
- Dersom statusresultatene blir automatisk flushet fra Azure table storage, vil status-endepunktet hente dataene direkte fra MongoDB'en