### PR TITLE
Removed logConfig from other places

### DIFF
--- a/DUSTActivity/index.js
+++ b/DUSTActivity/index.js
@@ -1,4 +1,4 @@
-const { logger, logConfig } = require('@vtfk/logger')
+const { logger } = require('@vtfk/logger')
 const { DEFAULT_CALLER } = require('../config')
 const { generate } = require('../lib/user-query')
 const { updateRequest } = require('../lib/mongo/handle-mongo')
@@ -9,13 +9,6 @@ module.exports = async function (context) {
   const { instanceId, system, user, token } = context.bindings.request
   const caller = (token && token.upn) || DEFAULT_CALLER
   const result = { name: system, started: new Date().toISOString() }
-
-  logConfig({
-    azure: {
-      context,
-      excludeInvocationId: true
-    }
-  })
 
   try {
     result.query = generate(system, user)

--- a/WorkerActivity/index.js
+++ b/WorkerActivity/index.js
@@ -1,4 +1,4 @@
-const { logger, logConfig } = require('@vtfk/logger')
+const { logger } = require('@vtfk/logger')
 const { newRequest, updateRequest } = require('../lib/mongo/handle-mongo')
 const { validate } = require('../lib/user-query')
 const updateUser = require('../lib/update-user')
@@ -14,13 +14,6 @@ const getSystems = results => {
 
 module.exports = async function (context) {
   const { type, variant, query } = context.bindings.request
-
-  logConfig({
-    azure: {
-      context,
-      excludeInvocationId: true
-    }
-  })
 
   if (type === 'db' && variant === 'new') {
     return await newRequest(query)

--- a/lib/auth/with-token-auth.js
+++ b/lib/auth/with-token-auth.js
@@ -31,7 +31,7 @@ module.exports = async (context, request, next) => {
       prefix: `${instanceId} -- ${validatedToken.upn}`,
       azure: {
         context,
-        excludeInvocationId: next.name === 'handleSearch'
+        excludeInvocationId: true
       }
     })
     return next(context, request)
@@ -40,7 +40,7 @@ module.exports = async (context, request, next) => {
       prefix: `${instanceId}`,
       azure: {
         context,
-        excludeInvocationId: next.name === 'handleSearch'
+        excludeInvocationId: true
       }
     })
     logger('error', ['with-token-auth', request.url, 'invalid-token', error && error.message ? typeof error.message === 'object' ? JSON.stringify(error.message, null, 2) : error.message : ''])


### PR DESCRIPTION
`logConfig` was used several places to exclude **invocationId**, making the logger in some cases removing the **instanceId** as well